### PR TITLE
CHANGE: control server will use control_server_port setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ cfg/*.bak
 
 # compile information
 compile_commands.json
+compile_commands.events.json
 .cache/

--- a/cfg/example_cloudlab.cfg
+++ b/cfg/example_cloudlab.cfg
@@ -109,6 +109,7 @@ nodes = (
 
         ip_address = "10.10.1.1";
         port = 8083;
+        control_server_port = 8084;
 
         // RDMA device index
         device_idx = 2;
@@ -123,6 +124,7 @@ nodes = (
 
         ip_address = "10.10.1.2";
         port = 8083;
+        control_server_port = 8084;
 
         // RDMA device index
         device_idx = 2;
@@ -137,6 +139,7 @@ nodes = (
 
         ip_address = "10.10.1.3";
         port = 8083;
+        control_server_port = 8084;
 
         // RDMA device index
         device_idx = 2;
@@ -165,7 +168,7 @@ tenants = (
 auto_scaler = {
     hostname = "node1.x5.kkprojects-pg0.utah.cloudlab.us";
     ip_address = "10.10.1.2";
-    port = 8084;
+    port = 8085;
 
 };
 

--- a/cfg/example_mutli_node.cfg
+++ b/cfg/example_mutli_node.cfg
@@ -109,6 +109,7 @@ nodes = (
 
         ip_address = "10.10.1.1";
         port = 8083;
+        control_server_port = 8084;
 
         // RDMA device index
         device_idx = 2;
@@ -123,6 +124,7 @@ nodes = (
 
         ip_address = "10.10.1.2";
         port = 8083;
+        control_server_port = 8084;
 
         // RDMA device index
         device_idx = 2;
@@ -151,7 +153,7 @@ tenants = (
 auto_scaler = {
     hostname = "node1.x5.kkprojects-pg0.utah.cloudlab.us";
     ip_address = "10.10.1.2";
-    port = 8084;
+    port = 8085;
 
 };
 

--- a/src/control_server.c
+++ b/src/control_server.c
@@ -52,7 +52,7 @@ int control_server_socks_init()
     uint32_t connected_nodes = 0;
     for (size_t i = 0; i < self_idx; i++)
     {
-        sprintf(buffer, "%u", cfg->nodes[i].port);
+        sprintf(buffer, "%u", cfg->nodes[i].control_server_port);
 
         do
         {
@@ -69,7 +69,7 @@ int control_server_socks_init()
     {
         return 0;
     }
-    sprintf(buffer, "%u", cfg->nodes[self_idx].port);
+    sprintf(buffer, "%u", cfg->nodes[self_idx].control_server_port);
     int bind_fd = sock_utils_bind(buffer);
     if (bind_fd <= 0)
     {

--- a/src/include/spright.h
+++ b/src/include/spright.h
@@ -88,6 +88,7 @@ struct spright_cfg_s
         char hostname[HOSTNAME_MAX];
         char ip_address[64];
         uint16_t port;
+        uint16_t control_server_port;
         uint32_t device_idx;
         uint32_t sgid_idx;
         uint32_t qp_num;

--- a/src/shm_mgr.c
+++ b/src/shm_mgr.c
@@ -113,6 +113,7 @@ static void cfg_print(void)
         printf("\tHostname: %s\n", cfg->nodes[i].hostname);
         printf("\tIP Address: %s\n", cfg->nodes[i].ip_address);
         printf("\tPort = %u\n", cfg->nodes[i].port);
+        printf("\tControl server port = %u\n", cfg->nodes[i].control_server_port);
         printf("\tdevice_idx = %u\n", cfg->nodes[i].device_idx);
         printf("\tsgid_idx = %u\n", cfg->nodes[i].sgid_idx);
         printf("\tib_port = %u\n", cfg->nodes[i].ib_port);
@@ -462,6 +463,15 @@ static int cfg_init(char *cfg_file)
         }
 
         cfg->nodes[id].port = port;
+
+        ret = config_setting_lookup_int(subsetting, "control_server_port", &port);
+        if (unlikely(ret == CONFIG_FALSE))
+        {
+            log_warn("Node control server port is missing.");
+            goto error;
+        }
+
+        cfg->nodes[id].control_server_port = port;
 
         ret = config_setting_lookup_int(subsetting, "device_idx", &value);
         if (unlikely(ret == CONFIG_FALSE))


### PR DESCRIPTION
control server is responsible for accepting control plane requests
priviously control server will init with the per node `port` field in cfg files
to avoid collision with other sockets connections
the control server will use the per node `control_server_port` to init